### PR TITLE
Explain GA tracking code should be inserted in <head>, not at bottom of the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To add the 18F snippet:
 
 * Copy the code below
 * Replace the `<<UA-CODE>>` with the ua-code that you got from the Analytics Guild
-* Add to the bottom of page before the `</body>`
+* Place it immediately before the closing `</head>` tag
 
 ```javascript
 <script>


### PR DESCRIPTION
When using the latest Google Universal Analytics code, the code snippet should be inserted in the `<head>` for best performance and comprehensiveness of data:

https://support.google.com/analytics/answer/1008080?hl=en#GA

Modern Google Analytics tracking code loads asynchronously and will not affect website performance; placing it higher in page load order will also better ensure that the pageview is tracked. With older tracking code it was encouraged to place at the bottom of the page for performance reasons, but this is no longer necessary.
